### PR TITLE
Add parm@Frosst atom-type loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Parm@Frosst download
+parm_at_Frosst.tgz

--- a/hgfp/data/parm_at_Frosst/parm_at_Frosst.py
+++ b/hgfp/data/parm_at_Frosst/parm_at_Frosst.py
@@ -1,0 +1,67 @@
+"""Fetch molecules and assigned types from http://www.ccl.net/cca/data/parm_at_Frosst/ ,
+define a generator that yields (openff_molecule, one_hot_atom_types) pairs."""
+
+import tarfile
+from os.path import exists
+
+import numpy as np
+from openforcefield.topology import Molecule
+
+fname = 'parm_at_Frosst.tgz'
+url = 'http://www.ccl.net/cca/data/parm_at_Frosst/parm_at_Frosst.tgz'
+
+# download if we haven't already
+if not exists(fname):
+    print('Downloading {} from {}...'.format(fname, url))
+    import urllib.request
+
+    urllib.request.urlretrieve(url, fname)
+
+# extract zinc and parm@frosst atom types
+archive = tarfile.open(fname)
+
+zinc_file = archive.extractfile('parm_at_Frosst/zinc.sdf')
+zinc_p_f_types_file = archive.extractfile('parm_at_Frosst/zinc_p_f_types.txt')
+
+zinc_p_f_types = [l.strip() for l in zinc_p_f_types_file.readlines()]
+zinc_mols = Molecule.from_file(
+    zinc_file,
+    file_format='sdf',
+    allow_undefined_stereo=True)
+
+archive.close()
+
+# convert types from strings to ints, for one-hot encoding
+unique_types = sorted(list(set(zinc_p_f_types)))
+n_types = len(unique_types)
+type_to_int = dict(zip(unique_types, range(len(unique_types))))
+type_ints = np.array([type_to_int[t] for t in zinc_p_f_types])
+
+
+# define generators
+def zinc_p_f_atom_types_generator():
+    """generate (openforcefield.topology.Molecule, np.array) pairs"""
+    current_index = 0
+    for mol in zinc_mols:
+        y = np.zeros((mol.n_atoms, n_types))
+        for i in range(mol.n_atoms):
+            y[i, type_ints[current_index]] = 1
+            current_index += 1
+        yield (mol, y)
+
+
+# TODO: zinc_am1bcc_atom_types
+# TODO: zinc_am1bcc_bond_types
+
+# TODO: mmff94_p_f_atom_types
+# TODO: mmff94_am1bcc_atom_types
+# TODO: mmff94_am1bcc_bond_types
+
+
+if __name__ == '__main__':
+    from tqdm import tqdm
+
+    print('sanity-checking shapes and row sums...')
+    for (mol, y) in tqdm(zinc_p_f_atom_types_generator()):
+        assert (y.shape == (mol.n_atoms, n_types))
+        assert ((y.sum(1) == 1).all())


### PR DESCRIPTION
Generator that yields (molecule, one_hot_atom_type_matrix) pairs from http://www.ccl.net/cca/data/parm_at_Frosst/ . @yuanqing-wang may want to use this as a "positive control" node classification task to help assess a model's sensitivity to relevant attributes of an atom's chemical environment.

This yields 7,535 molecules from ZINC, with a total of 217,616 atoms classified into 45 parm@Frosst atom types. (Later can read off the analogous targets for am1bcc atom and bond types.)

Here are the atom type names in descending order of popularity amongst the ZINC:
```
CA: 37140
HA: 28850
HC: 28374
CT: 22172
H1: 17322
NB: 7607
C: 5966
H: 5649
CR: 5293
CC: 5290
CW: 5290
H4: 5064
O: 4856
OS: 4764
CM: 3857
NC: 3538
N: 3194
CB: 2965
S: 2562
O2: 2208
N2: 2003
Nstar: 1845
H5: 1105
NA: 1101
F: 1006
N3: 997
OH: 996
HO: 927
H2: 883
CP: 806
C2: 779
SO: 596
NL: 585
CL: 582
Cstar: 579
CJ: 352
HP: 228
BR: 84
HX: 70
Su: 57
Ou: 30
H3: 23
I: 8
Nu: 8
P: 5
```